### PR TITLE
fix(hydroponics): now layed mobs ignore bananapeel

### DIFF
--- a/code/modules/hydroponics/grown_inedible.dm
+++ b/code/modules/hydroponics/grown_inedible.dm
@@ -63,5 +63,5 @@
 /obj/item/weapon/bananapeel/Crossed(mob/living/M)
 	if(!istype(M))
 		return
-	if(M.m_intent != M_WALK)
+	if(!resting && M.m_intent != M_WALK)
 		M.slip_on_obj(src, 2, 2)


### PR DESCRIPTION
fix #5451

<details>
<summary>Чейнджлог</summary>

```yml
🆑
bugfix: Больше лежащие/ползущие мобы не подскальзываются на банановой кожуре.
/🆑
```

</details>

- [x] Pull Request полностью завершен, мне не нужна помощь чтобы его закончить.
- [x] Я внимательно прочитал все свои изменения и багов в них не нашел.
- [ ] Я запускал сервер со своими изменениями локально и все протестировал.
- [x] Я ознакомился c [Guide to Contribute](https://github.com/ChaoticOnyx/OnyxBay/blob/dev/docs/contributing.md).
